### PR TITLE
Enable X11 forwarding

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,7 @@ SCRIPT
 Vagrant.configure('2') do |config|
     config.vm.box = 'precise32'
     config.vm.box_url = 'http://files.vagrantup.com/precise32.box'
+    config.ssh.forward_x11 = true
 
     config.vm.provider 'virtualbox' do |v|
         v.customize ['modifyvm', :id, '--usb', 'on']


### PR DESCRIPTION
At least allows `gnuradio-companion` to be run after the initial build.
